### PR TITLE
Custom ping-lite module

### DIFF
--- a/desktop/app/main-process/ping-lite.js
+++ b/desktop/app/main-process/ping-lite.js
@@ -1,0 +1,118 @@
+// Modified ping-lite library made by ben-bradley.
+
+var spawn = require('child_process').spawn,
+    events = require('events'),
+    fs = require('fs'),
+    WIN = /^win/.test(process.platform),
+    LIN = /^linux/.test(process.platform),
+    MAC = /^darwin/.test(process.platform);
+
+module.exports = Ping;
+
+function Ping(host, options) {
+  if (!host)
+    throw new Error('You must specify a host to ping!');
+
+  this._host = host;
+  this._options = options = (options || {});
+
+  events.EventEmitter.call(this);
+
+  if (WIN) {
+    console.log("A");
+    this._bin = 'c:/windows/system32/ping.exe';
+    this._args = (options.args) ? options.args : [ '-n', '1', '-w', '5000', host ];
+    this._regmatch = /[><=]([0-9.]+?)ms/; // No space before "ms"
+  }
+  else if (LIN) {
+    this._bin = '/bin/ping';
+    this._args = (options.args) ? options.args : [ '-n', '-w', '2', '-c', '1', host ];
+    this._regmatch = /=([0-9.]+?) ms/; // need to verify this
+  }
+  else if (MAC) {
+    this._bin = '/sbin/ping';
+    this._args = (options.args) ? options.args : [ '-n', '-t', '2', '-c', '1', host ];
+    this._regmatch = /=([0-9.]+?) ms/;
+  }
+  else {
+    throw new Error('Could not detect your ping binary.');
+  }
+
+  if (!fs.existsSync(this._bin))
+    throw new Error('Could not detect '+this._bin+' on your system');
+
+  this._i = 0;
+
+  return this;
+}
+
+Ping.prototype.__proto__ = events.EventEmitter.prototype;
+
+// SEND A PING
+// ===========
+Ping.prototype.send = function(callback) {
+  var self = this;
+  callback = callback || function(err, ms) {
+    if (err) return self.emit('error', err);
+    else     return self.emit('result', ms);
+  };
+
+  var _ended, _exited, _errored;
+
+  this._ping = spawn(this._bin, this._args); // spawn the binary
+
+  this._ping.on('error', function(err) { // handle binary errors
+    _errored = true;
+    callback(err);
+  });
+
+  this._ping.stdout.on('data', function(data) { // log stdout
+    this._stdout = (this._stdout || '') + data;
+  });
+
+  this._ping.stdout.on('end', function() {
+    _ended = true;
+    if (_exited && !_errored) onEnd.call(self._ping);
+  });
+
+  this._ping.stderr.on('data', function(data) { // log stderr
+    this._stderr = (this._stderr || '') + data;
+  });
+
+  this._ping.on('exit', function(code) { // handle complete
+    _exited = true;
+    if (_ended && !_errored) onEnd.call(self._ping);
+  });
+
+  function onEnd() {
+    var stdout = this.stdout._stdout,
+        stderr = this.stderr._stderr,
+        ms;
+
+    if (stderr)
+      return callback(new Error(stderr));
+    else if (!stdout)
+      return callback(new Error('No stdout detected'));
+
+    ms = stdout.match(self._regmatch); // parse out the ##ms response
+    ms = (ms && ms[1]) ? Number(ms[1]) : ms;
+
+    callback(null, ms);
+  }
+};
+
+// CALL Ping#send(callback) ON A TIMER
+// ===================================
+Ping.prototype.start = function(callback) {
+  var self = this;
+  this._i = setInterval(function() {
+    self.send(callback);
+  }, (self._options.interval || 5000));
+  self.send(callback);
+};
+
+// STOP SENDING PINGS
+// ==================
+Ping.prototype.stop = function() {
+  clearInterval(this._i);
+};

--- a/desktop/app/main-process/ping-lite.js
+++ b/desktop/app/main-process/ping-lite.js
@@ -19,7 +19,6 @@ function Ping(host, options) {
   events.EventEmitter.call(this);
 
   if (WIN) {
-    console.log("A");
     this._bin = 'c:/windows/system32/ping.exe';
     this._args = (options.args) ? options.args : [ '-n', '1', '-w', '5000', host ];
     this._regmatch = /[><=]([0-9.]+?)ms/; // No space before "ms"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -2307,11 +2307,6 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
-    "ping-lite": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ping-lite/-/ping-lite-2.0.2.tgz",
-      "integrity": "sha512-LFh9a6axDrC5OBjcUCqeQ0Ih6Losk5uPOTdyV7v/x91c4TqQqAiciFoInsdX8J+KggpYOpC6ruJlRp6KgGwDzA=="
-    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,7 +24,6 @@
     "electron-log": "^3.0.6",
     "electron-updater": "^4.0.6",
     "glob": "^7.1.4",
-    "ping-lite": "^2.0.2",
     "simple-node-logger": "^18.12.24",
     "sudo-prompt": "^8.2.5"
   },


### PR DESCRIPTION
The original ping-lite module is broken (at least in Windows). It'll always return null just because of a wrong regmatch. As a result, the whole program is rendered useless, since it relies heavily on the ping result.

Can't check for the other OS, as they should be dependent on how the each system ping output is formatted.