### PR TITLE
Update SDR URL

### DIFF
--- a/app/services/servers.js
+++ b/app/services/servers.js
@@ -6,7 +6,7 @@ let serversList = null;
 ServersService.prototype.getServersList = function () {
   if (serversList === null) {
     serversList = Axios({
-      url: `https://raw.githubusercontent.com/SteamDatabase/SteamTracking/master/Random/NetworkDatagramConfig.json`,
+      url: `https://steamcdn-a.akamaihd.net/apps/sdr/network_config.json`,
       method: 'get'
     })
   }


### PR DESCRIPTION
Updates the URL used to get info about relays to the official Valve one (https://steamcdn-a.akamaihd.net/apps/sdr/network_config.json).
This is the upstream URL is used by the current provider, SteamDatabase/SteamTracking, as can be seen [here](https://github.com/SteamDatabase/SteamTracking/blob/85fa694a3d9b5717570a9579efd8948d423f9d7c/urls.txt#L514).

Thanks,
Elliott