### PR TITLE
Fix server list URL

### DIFF
--- a/app/services/servers.js
+++ b/app/services/servers.js
@@ -6,7 +6,7 @@ let serversList = null;
 ServersService.prototype.getServersList = function () {
   if (serversList === null) {
     serversList = Axios({
-      url: `https://raw.githubusercontent.com/SteamDatabase/SteamTracking/master/Random/NetworkDatagramConfig.json`,
+      url: `https://api.steampowered.com/ISteamApps/GetSDRConfig/v1?appid=730`,
       method: 'get'
     })
   }


### PR DESCRIPTION
The URL was invalid so I updated it.

Thank the SteamDB Discord for the updated URL.

This fixes #112, #110 and #108